### PR TITLE
fix datastore paginate off by one

### DIFF
--- a/app/client/src/Components/dataExplorer.js
+++ b/app/client/src/Components/dataExplorer.js
@@ -142,7 +142,7 @@ function DataExplorer(props) {
                     <Button onClick={() => handlePage(-1)} disabled={Boolean(activePage === 1)} color="blue" icon>
                         <Icon name='angle left' />
                     </Button>
-                    <Button onClick={() => handlePage(1)} disabled={Boolean(DataStores.length % (DataPerPage + 1) !== 0 && activePage === Math.ceil(DataStores.length / DataPerPage))} color="blue" icon>
+                    <Button onClick={() => handlePage(1)} disabled={Boolean(activePage === Math.ceil(DataStores.length / DataPerPage))} color="blue" icon>
                         <Icon name='angle right' />
                     </Button>
                 </>


### PR DESCRIPTION
Fixing datastore explorer page view, paginate next button disabling off by one correction.